### PR TITLE
Failed Index-Creation caused by dash

### DIFF
--- a/src/Connectors.Memory.SqlServer/SqlServerClient.cs
+++ b/src/Connectors.Memory.SqlServer/SqlServerClient.cs
@@ -97,7 +97,7 @@ public sealed class SqlServerClient : ISqlServerClient
                     );
                     
                     IF OBJECT_ID(N'{this._configuration.Schema}.IXC_{$"{this._configuration.EmbeddingsTableName}_{collectionName}"}', N'U') IS NULL
-                    CREATE CLUSTERED COLUMNSTORE INDEX IXC_{$"{this._configuration.EmbeddingsTableName}_{collectionName}"}
+                    CREATE CLUSTERED COLUMNSTORE INDEX [IXC_{$"{this._configuration.EmbeddingsTableName}_{collectionName}"}]
                     ON {this.GetFullTableName($"{this._configuration.EmbeddingsTableName}_{collectionName}")};";
 
             command.Parameters.AddWithValue("@collectionName", collectionName);


### PR DESCRIPTION
Added []-Brackets to "create clustered index", cause SQL-Server couldn't handle collectionname "Handbook-for-something"

## Description

What's new?

- Added Brackets to "create clustered index"

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Tests
- [ ] Other